### PR TITLE
Smarter partitions

### DIFF
--- a/GCLOUD.md
+++ b/GCLOUD.md
@@ -5,10 +5,3 @@
 gcloud init
 ```
   - zone: __us-east1-d__
-
-- start/stop cluster:
-
-```bash
-bin/g-cluster.sh start
-bin/g-cluster.sh stop
-```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@
   - `gset`
 - __NODE_EVENT_NUMBER__: number of events to be performed in
 the simulation. The event interval is 1 second
+- __PARTITION_NUMBER__: number of connected components to be formed
+during the simulation. The partition is induced when the simulation
+reaches 25% of progress and healed at 75%. With static memberships
+it's easy to have control on the number of connected components
+created; but it's not the case if using HyParView.
 
 
 #### Kubernetes

--- a/README.md
+++ b/README.md
@@ -37,13 +37,24 @@ created; but it's not the case if using HyParView.
 #### Kubernetes
 
 ```bash
-$ WHAT=run bin/sim.sh
+$ bin/sim.sh run
+$ bin/sim.sh build
+$ bin/sim.sh
 ```
 
-- `WHAT=run` will run the experiments without pullling a new image
-- `WHAT=build` will build a new image, push it, and the run the experiments with that image
+- `run` will run the experiments without pullling a new image
+- `build` will build a new image, push it, and the run the experiments with that image
 - otherwise, it will use an image that clones the repository in the current branch
 
+
+#### Google Cloud Platform
+
+- To start and stop the cluster:
+
+```bash
+$ bin/g-cluster.sh start
+$ bin/g-cluster.sh stop
+```
 
 ##### Tail the logs
 
@@ -57,6 +68,14 @@ $ kubectl logs -f lsim-1488549530072065763-3946360666-0b6d8
 
 
 ##### lsim dashboard
+
+- To start the dashboard:
+```bash
+$ bin/lsim-dash-deploy.sh
+```
+
+- To open the dashboard:
+
 ```bash
 $ bin/dash-proxy.sh
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - __SIMULATION__:
   - `gcounter`
   - `gset`
+  - `awset`
 - __NODE_EVENT_NUMBER__: number of events to be performed in
 the simulation. The event interval is 1 second
 - __PARTITION_NUMBER__: number of connected components to be formed

--- a/bin/sim.sh
+++ b/bin/sim.sh
@@ -6,7 +6,7 @@ BRANCH=$(git branch |
          grep "^\*" |
          awk '{print $2}')
 
-if [ "${WHAT}" == "build" ]; then
+if [ "$1" == "build" ]; then
   # build and push a new image
   IMAGE=vitorenesduarte/lsim
   PULL_IMAGE=Always
@@ -16,7 +16,7 @@ if [ "${WHAT}" == "build" ]; then
     IMAGE=${IMAGE} \
     DOCKERFILE=${DOCKERFILE} "${DIR}"/image.sh
 
-elif [ "${WHAT}" == "run" ]; then
+elif [ "$1" == "run" ]; then
   # use the latest image
   IMAGE=vitorenesduarte/lsim
   PULL_IMAGE=IfNotPresent
@@ -29,10 +29,6 @@ fi
 
 # start redis
 "${DIR}"/redis-deploy.sh
-
-# start lsim-dash
-#"${DIR}"/lsim-dash-deploy.sh
-
 
 # lsim configuration
 OVERLAY_=(ring)

--- a/bin/sim.sh
+++ b/bin/sim.sh
@@ -33,16 +33,16 @@ fi
 # lsim configuration
 OVERLAY_=(ring)
 SIMULATION_=(gset)
-NODE_NUMBER_=(3)
-NODE_EVENT_NUMBER_=(100)
-PARTITION_NUMBER_=(1)
+NODE_NUMBER_=(20)
+NODE_EVENT_NUMBER_=(200)
+PARTITION_NUMBER_=(1 2 3 4)
 
 # ldb configuration
 MODE_=(state_based delta_based)
 DRIVEN_MODE_=(none)
 STATE_SYNC_INTERVAL_=(1000)
-REDUNDANT_DGROUPS_=(false true)
-DGROUP_BACK_PROPAGATION_=(false true)
+REDUNDANT_DGROUPS_=(true)
+DGROUP_BACK_PROPAGATION_=(true)
 
 # shellcheck disable=SC2034
 for REP in $(seq 1 $REPS)

--- a/src/lsim_simulation_runner.erl
+++ b/src/lsim_simulation_runner.erl
@@ -83,7 +83,7 @@ handle_info(event, #state{event_count=Events0,
     Events = Events0 + 1,
     EventFun(Events),
     TotalEvents = TotalEventsFun(),
-    ?LOG("Event ~p | Observed ~p | Node ~p", [Events, TotalEvents, node()]),
+    ?LOG("Event ~p | Observed ~p | Node ~p", [Events, TotalEvents, ldb_config:id()]),
 
     case Events == node_event_number() of
         true ->
@@ -98,7 +98,7 @@ handle_info(event, #state{event_count=Events0,
 handle_info(simulation_end, #state{total_events_fun=TotalEventsFun,
                                    check_end_fun=CheckEndFun}=State) ->
     TotalEvents = TotalEventsFun(),
-    ?LOG("Events observed ~p | Node ~p", [TotalEvents, node()]),
+    ?LOG("Events observed ~p | Node ~p", [TotalEvents, ldb_config:id()]),
 
     case CheckEndFun(node_number(), node_event_number()) of
         true ->

--- a/src/lsim_simulations.erl
+++ b/src/lsim_simulations.erl
@@ -112,7 +112,8 @@ simple_set_simulation(Type) ->
         ldb:create(?KEY, Type)
     end,
     EventFun = fun(EventNumber) ->
-        Element = atom_to_list(node()) ++
+        MyName = ldb_config:id(),
+        Element = atom_to_list(MyName) ++
                   integer_to_list(EventNumber),
         ldb:update(?KEY, {add, Element})
     end,


### PR DESCRIPTION
- When creating a partition is not enough to say for each node, the set of nodes it cannot contact
- This gives very little control on what's the resulting overlay
- With static memberships, when we say `PARTITION_NUMBER=2` it should mean the number of connected components is 2, and not there are 2 groups of nodes that can contact each other